### PR TITLE
Fixed first call to substring().

### DIFF
--- a/Sms.Splitter/UnicodeSplitter.cs
+++ b/Sms.Splitter/UnicodeSplitter.cs
@@ -76,7 +76,8 @@ namespace Sms.Splitter
             {
                 Bytes = walker.Bytes,
                 Length = walker.Length,
-                Content = partEnd.HasValue ? content.Substring(walker.PartStart, partEnd.Value + 1) : content.Substring(walker.PartStart)
+                //Content = partEnd.HasValue ? content.Substring(walker.PartStart, partEnd.Value + 1) : content.Substring(walker.PartStart)
+                Content = partEnd.HasValue ? content.Substring(walker.PartStart, (partEnd.Value + 1) - walker.PartStart) : content.Substring(walker.PartStart)
             });
             result.TotalBytes += walker.Bytes;
             result.TotalLength += walker.Length;


### PR DESCRIPTION
substring()'s second parameter should be length not the end index.  Original code caused unhandled exception re. length exceeding string length.